### PR TITLE
Add a direct link to Google Colab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
-# USD-Tutorials-And-Examples
-USD educational materials
+# USD Tutorials and Examples
+
+## About
+This project showcases educational material for [Pixar's Universal Scene Description](https://graphics.pixar.com/usd/docs/index.html) (USD).
+
+Follow along by opening the enclosed Jupyter Notebook in Google Colaboratory: [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NVIDIA-Omniverse/USD-Tutorials-And-Examples/blob/main/ColaboratoryNotebooks/usd_introduction.ipynb)


### PR DESCRIPTION
Add a direct link to Google Colab from the _README.md_ file to make it easier for individuals to jump right into an environment and start coding.