### PR TITLE
Update notebook sample formatting

### DIFF
--- a/ColaboratoryNotebooks/usd_introduction.ipynb
+++ b/ColaboratoryNotebooks/usd_introduction.ipynb
@@ -328,6 +328,22 @@
       ]
     },
     {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "lZ-dCTRkHNhL"
+      },
+      "source": [
+        "## Understanding Variants\n",
+        "\n",
+        "Variants and VariantSets allow a content author to provide a prim with multiple looks or forms with relative ease. \n",
+        "\n",
+        "From the [USD Glossary](https://graphics.pixar.com/usd/docs/USD-Glossary.html#USDGlossary-VariantSet):\n",
+        "> A *VariantSet* is a composition arc that allows a content creator to package a discrete set of alternatives, between which a downstream consumer is able to non-destructively switch, or augment.  A reasonable way to think about VariantSets is as a \"switchable reference\".  Each Variant of a VariantSet encapsulates a tree of scene description that will be composed onto the prim on which the VariantSet is defined, when the Variant is selected.  VariantSet names must be legal USD identifiers.\n",
+        "\n",
+        "In the following example we will show how to add a VariantSet that lets the content creator select different colors for their sphere."
+      ]
+    },
+    {
       "cell_type": "code",
       "metadata": {
         "colab": {


### PR DESCRIPTION
## Goal
Update the formatting of the sample notebook file included in the repository, to make it more welcoming to Users.

For an easier review, the changes of this Pull Request can be rendered in context from GitHub, which should make it simpler than reviewing raw JSON: https://github.com/NVIDIA-Omniverse/USD-Tutorials-And-Examples/blob/update-notebook-sample-formatting/ColaboratoryNotebooks/usd_introduction.ipynb

## Description
This changeset makes a few changes that may make it more welcoming to Users attempting to follow along the USD tutorial, by:
 * Fixing a few typos
 * Standardizing code block formatting
 * Removing a superfluous code block?