### PR TITLE
Add more background information about Google Colab

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ Follow along the tutorial using the sample notebook from the GTC session:
 ## Additional Resources
  * [Pixar's USD](https://graphics.pixar.com/usd)
  * [USD at NVIDIA](https://usd.nvidia.com)
- * [USD training content on _NVIDIA On-Demand_](https://www.nvidia.com/en-us/on-demand/search/?facet.mimetype[]=event%20session&page=1&q=usd&sort=date)
+ * [USD training content on _NVIDIA On-Demand_](https://www.nvidia.com/en-us/on-demand/playlist/playList-911c5614-4b7f-4668-b9eb-37f627ac8d17/)

--- a/README.md
+++ b/README.md
@@ -11,9 +11,13 @@ For convenience, the Jupyter notebook from the GTC session is available on Googl
 Should you prefer to run the notebook on your local machine instead, simply download and execute it after [installing Jupyter](https://jupyter.org).
 
 ## Sample Notebook
-
 Follow along the tutorial using the sample notebook from the GTC session:
 
 |Notebook|Google Colab link|
 |--------|:----------------:|
 |Introduction to USD|[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NVIDIA-Omniverse/USD-Tutorials-And-Examples/blob/main/ColaboratoryNotebooks/usd_introduction.ipynb)|
+
+## Additional Resources
+ * [Pixar's USD](https://graphics.pixar.com/usd)
+ * [USD at NVIDIA](https://usd.nvidia.com)
+ * [USD training content on _NVIDIA On-Demand_](https://www.nvidia.com/en-us/on-demand/search/?facet.mimetype[]=event%20session&page=1&q=usd&sort=date)

--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ Should you prefer to run the notebook on your local machine instead, simply down
 Follow along the tutorial using the sample notebook from the GTC session:
 
 |Notebook|Google Colab link|
-|--------|:-----------------:|
+|--------|:----------------:|
 |Introduction to USD|[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NVIDIA-Omniverse/USD-Tutorials-And-Examples/blob/main/ColaboratoryNotebooks/usd_introduction.ipynb)|

--- a/README.md
+++ b/README.md
@@ -3,4 +3,17 @@
 ## About
 This project showcases educational material for [Pixar's Universal Scene Description](https://graphics.pixar.com/usd/docs/index.html) (USD).
 
-Follow along by opening the enclosed Jupyter Notebook in Google Colaboratory: [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NVIDIA-Omniverse/USD-Tutorials-And-Examples/blob/main/ColaboratoryNotebooks/usd_introduction.ipynb)
+For convenience, the Jupyter notebook from the GTC session is available on Google Colaboratory, which offers an interactive environment from the comfort of your web browser.  Colaboratory makes it possible to:
+ * Try code snippets without building or installing USD on your machine
+ * Run the samples on any device
+ * Share code experiments with others
+
+Should you prefer to run the notebook on your local machine instead, simply download and execute it after [installing Jupyter](https://jupyter.org).
+
+## Sample Notebook
+
+Follow along the tutorial using the sample notebook from the GTC session:
+
+|Notebook|Google Colab link|
+|--------|:-----------------:|
+|Introduction to USD|[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NVIDIA-Omniverse/USD-Tutorials-And-Examples/blob/main/ColaboratoryNotebooks/usd_introduction.ipynb)|


### PR DESCRIPTION
## Goal
Provide more information about Google Colaboratory from the repository's main page.

To make it easier to review the content of the documentation, the rendered Markdown file can be viewed directly here: https://github.com/NVIDIA-Omniverse/USD-Tutorials-And-Examples/blob/provide-background-information-about-colaboratory/README.md

## Description
This changeset should make it more welcoming to individuals wishing to learn more about USD, or following along the GTC 2021 introductory session about USD. By providing some context about what Google Colaboratory is, and what are Jupyter notebooks, the intent is for individuals landing on the repository to know what to expect from the learning material it contains.

This also opens the door to adding more similar training and educational material over time, by simply contributing additional educational content to the repository and adding direct links to Colaboratory.