### PR TITLE
Add USD tutorials from NVIDIA website

### DIFF
--- a/ColaboratoryNotebooks/hierarchy_and_traversal.ipynb
+++ b/ColaboratoryNotebooks/hierarchy_and_traversal.ipynb
@@ -1,0 +1,194 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "hierarchy-and-traversal.ipynb",
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "IftoR-r0D6R0"
+      },
+      "source": [
+        "# USD Tutorial: Hierarchy and Traversal\n",
+        "\n",
+        "**To run this sample:** click _Runtime_ > _Run all_ from the top menu, or use the <kbd>⌘</kbd>/<kbd>CTRL</kbd>+<kbd>F9</kbd> keyboard shortcut."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "nyWofqfjEmNk"
+      },
+      "source": [
+        "## Install the `usd-core` Python package\n",
+        "\n",
+        "Install the [`usd-core`](https://pypi.org/project/usd-core/) Python package providing the core USD libraries. Note that it does not provide any of the optional plugins or imaging features from the complete USD distribution."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "RjqwbEkREoUb"
+      },
+      "source": [
+        "! pip install usd-core\n",
+        "\n",
+        "# See https://pypi.org/project/usd-core/#history for a list of supported USD\n",
+        "# versions."
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "PkN9Gs6NIBIj"
+      },
+      "source": [
+        "## Tutorial\n",
+        "\n",
+        "USD Stages are organized in a hierarchy of Prims: there is a special root prim at `/` and it may have N-number of direct Prim descendants, each of which can have their own tree of Prim descendants.\n",
+        "\n",
+        "The path to a Prim is described by a string which starts with the root prim `/` and contains the Prim name separated by the path separator `/` until the last component is the desired Prim's name.\n",
+        "\n",
+        "For example `/Car/Wheel/Tire` refers to the `Tire` prim which has parent `Wheel` and grandparent `Car`. `Car`'s parent is the special root prim `/`.\n",
+        "\n",
+        "In the Tutorial section on Stages there is information on how to retrieve a Prim at a given path using `stage_ref.GetPrimAtPath()`.\n",
+        "\n",
+        "Here is a refresher, we'll assume *car.usda* has the `/Car/Wheel/Tire` path:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "oJrApcfjIYcM"
+      },
+      "source": [
+        "%%file car.usda\n",
+        "#usda 1.0\n",
+        "def \"Car\" {\n",
+        "    def \"Wheel\" {\n",
+        "        def \"Tire\" {\n",
+        "            \n",
+        "        }\n",
+        "    }\n",
+        "}"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Rq-2a6pjIjgx"
+      },
+      "source": [
+        "from pxr import Usd\n",
+        "\n",
+        "stage_ref = Usd.Stage.Open('car.usda')\n",
+        "prim_ref = stage_ref.GetPrimAtPath('/Car')"
+      ],
+      "execution_count": 3,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "JirNBzx8IoGD"
+      },
+      "source": [
+        "Now, if you want to get a specific child of a Prim, and you know the name, you can use `prim_ref.GetChild(child_name)`:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "vurZazQCIlHc"
+      },
+      "source": [
+        "stage_ref = Usd.Stage.Open('car.usda')\n",
+        "\n",
+        "prim_ref = stage_ref.GetPrimAtPath('/Car')\n",
+        "child_prim_ref = prim_ref.GetChild('Wheel')\n",
+        "\n",
+        "# Prims can be cast as bool, so you can check if the prim exists by comparing\n",
+        "# its bool() overload\n",
+        "if child_prim_ref:\n",
+        "    print(\"/Car/Wheel exists\") # This will execute\n",
+        "\n",
+        "print(child_prim_ref.GetPath()) # Prints \"\"/Car/Wheel\""
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "yvCu6v_nIvgD"
+      },
+      "source": [
+        "If you want to get all the children of a Prim, you can use `prim_ref.GetChildren()` which returns a list of prim references:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "UVYAXLftIyY0"
+      },
+      "source": [
+        "stage_ref = Usd.Stage.Open('car.usda')\n",
+        "\n",
+        "prim_ref = stage_ref.GetPrimAtPath('/Car')\n",
+        "\n",
+        "# Will return [Usd.Prim(</Car/Wheel>)]\n",
+        "children_refs = prim_ref.GetChildren()"
+      ],
+      "execution_count": 5,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "QVgskWPGI0mr"
+      },
+      "source": [
+        "If you want to traverse the entire stage, the `stage_ref.Traverse()` function is perfect for that, it returns an iterator:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "FkRIiEmgI3a8"
+      },
+      "source": [
+        "stage_ref = Usd.Stage.Open('car.usda')\n",
+        "\n",
+        "for prim_ref in stage_ref.Traverse():\n",
+        "    print(prim_ref.GetPath())"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "qPyn-gVtI5UL"
+      },
+      "source": [
+        "There are more advanced traversal methods described in the [UsdStage](https://graphics.pixar.com/usd/docs/api/class_usd_stage.html#adba675b55f41cc1b305bed414fc4f178) documentation."
+      ]
+    }
+  ]
+}

--- a/ColaboratoryNotebooks/opening_stages.ipynb
+++ b/ColaboratoryNotebooks/opening_stages.ipynb
@@ -1,0 +1,160 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "opening-stages.ipynb",
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "IftoR-r0D6R0"
+      },
+      "source": [
+        "# USD Tutorial: Opening Stages\n",
+        "\n",
+        "**To run this sample:** click _Runtime_ > _Run all_ from the top menu, or use the <kbd>⌘</kbd>/<kbd>CTRL</kbd>+<kbd>F9</kbd> keyboard shortcut."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "nyWofqfjEmNk"
+      },
+      "source": [
+        "## Install the `usd-core` Python package\n",
+        "\n",
+        "Install the [`usd-core`](https://pypi.org/project/usd-core/) Python package providing the core USD libraries. Note that it does not provide any of the optional plugins or imaging features from the complete USD distribution."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "RjqwbEkREoUb"
+      },
+      "source": [
+        "! pip install usd-core\n",
+        "\n",
+        "# See https://pypi.org/project/usd-core/#history for a list of supported USD\n",
+        "# versions."
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ZNXYTKBzELR7"
+      },
+      "source": [
+        "## Tutorial\n",
+        "\n",
+        "Working with USD Stages is pretty straight forward, as most times everything is one function call away.\n",
+        "\n",
+        "To load a USD file as a USD Stage you use `Usd.Stage.Open(path)`:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "2-Z3qbXsE4Qs"
+      },
+      "source": [
+        "%%file sphere_sample.usda\n",
+        "#usda 1.0\n",
+        "def Sphere \"sphere\"\n",
+        "{\n",
+        "}"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "8A730ygjEyZ0"
+      },
+      "source": [
+        "from pxr import Usd\n",
+        "\n",
+        "stage = Usd.Stage.Open('sphere_sample.usda')"
+      ],
+      "execution_count": 3,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "b55FFtgcFMQs"
+      },
+      "source": [
+        "To create a new Stage use `Usd.Stage.CreateNew(path)`:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "OlgYaHQBFP67"
+      },
+      "source": [
+        "stage = Usd.Stage.CreateNew('a_new_stage.usd')  "
+      ],
+      "execution_count": 4,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "BRANR9wMFUO3"
+      },
+      "source": [
+        "To save a loaded Stage use `Usd.Stage.Save(path)`:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "uNk0nfjNFW3U"
+      },
+      "source": [
+        "stage = Usd.Stage.Open('sphere_sample.usda')\n",
+        "# Do something to the stage\n",
+        "stage.Save()  "
+      ],
+      "execution_count": 5,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "lEKbxlWXFbhW"
+      },
+      "source": [
+        "To export a stage to a new file, you can use `Usd.Stage.Export()`. This function allows you to transition between serialization formats (*usda* or *usdc*) as well, based on the file extension provided."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "3XsEIAAZFi8b"
+      },
+      "source": [
+        "stage = Usd.Stage.Open('sphere_sample.usda')\n",
+        "# Do something to the stage\n",
+        "stage.Export('sphere_sample.usdc')"
+      ],
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}

--- a/ColaboratoryNotebooks/prims_attributes_and_metadata.ipynb
+++ b/ColaboratoryNotebooks/prims_attributes_and_metadata.ipynb
@@ -1,0 +1,279 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "prims-attributes-and-metadata.ipynb",
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "IftoR-r0D6R0"
+      },
+      "source": [
+        "# USD Tutorial: Prims, Attributes and Metadata\n",
+        "\n",
+        "**To run this sample:** click _Runtime_ > _Run all_ from the top menu, or use the <kbd>⌘</kbd>/<kbd>CTRL</kbd>+<kbd>F9</kbd> keyboard shortcut."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "nyWofqfjEmNk"
+      },
+      "source": [
+        "## Install the `usd-core` Python package\n",
+        "\n",
+        "Install the [`usd-core`](https://pypi.org/project/usd-core/) Python package providing the core USD libraries. Note that it does not provide any of the optional plugins or imaging features from the complete USD distribution."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "RjqwbEkREoUb"
+      },
+      "source": [
+        "! pip install usd-core\n",
+        "\n",
+        "# See https://pypi.org/project/usd-core/#history for a list of supported USD\n",
+        "# versions."
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "gr8anrjrLkJU"
+      },
+      "source": [
+        "%%file sphere_sample.usda\n",
+        "#usda 1.0\n",
+        "def Sphere \"sphere\"\n",
+        "{\n",
+        "}"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Sl7Ua6G6FpKz"
+      },
+      "source": [
+        "## Tutorial\n",
+        "\n",
+        "### Prims\n",
+        "Working with Prims is a more complicated since Prims are extremely powerful objects in USD. Prims are referenced by their path in the stage, which is a string in the form of `/Prim/ChildPrim`. `/` is a special prim known as the root prim in a stage.\n",
+        "\n",
+        "To get a reference to a prim at a path use `stage_ref.GetPrimAtPath(path)`:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "9fJ8AuN1Fzwj"
+      },
+      "source": [
+        "from pxr import Sdf, Usd, UsdGeom\n",
+        "\n",
+        "stage_ref = Usd.Stage.Open('sphere_sample.usda')\n",
+        "\n",
+        "prim = stage_ref.GetPrimAtPath('/sphere')\n",
+        "print(prim.GetName()) # Prints \"sphere\"\n",
+        "print(prim.GetPrimPath()) # Prints \"/sphere\""
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "1clJziPQFzOb"
+      },
+      "source": [
+        "To define a new prim use `stage_ref.DefinePrim(path)`:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "HCCvIRfmGDEb"
+      },
+      "source": [
+        "stage_ref = Usd.Stage.Open('sphere_sample.usda')\n",
+        "\n",
+        "prim = stage_ref.DefinePrim('/UnTypedPrim')\n",
+        "print(prim.GetName()) # Prints \"UnTypedPrim\""
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "E82AGFcYGGaL"
+      },
+      "source": [
+        "To define a new prim with a type use `stage_ref.DefinePrim(path, type_name)` or you can use your Type's `SomeType.Define(stage_ref, path)` method:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "j-W-VHJ6GLY8"
+      },
+      "source": [
+        "stage_ref = Usd.Stage.Open('sphere_sample.usda')\n",
+        "\n",
+        "prim = stage_ref.DefinePrim('/XformPrim', 'Xform')\n",
+        "# Above we have a Usd.Prim, if we want to access all the Xform's types natively,\n",
+        "# we need to get an Xform instance of our prim\n",
+        "xform = UsdGeom.Xform(prim)\n",
+        "\n",
+        "print(xform.GetPath()) # Prints \"/XformPrim\"\n",
+        "\n",
+        "# It is often better to use the Define() method of your type right away, since\n",
+        "# it returns your typed instance rather than a Usd.Prim instance\n",
+        "\n",
+        "xform_faster = UsdGeom.Xform.Define(stage_ref, '/AnotherXformPrim')"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "r8zq9u2bGXU0"
+      },
+      "source": [
+        "To delete a prim from the current edit layer (please refer to the [documentation about RemovePrim](https://graphics.pixar.com/usd/docs/api/class_usd_stage.html#ac605faad8fc2673263775b1eecad2955) for details) you can use `stage_ref.RemovePrim(path)`:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Ld7Zz88YGf3b"
+      },
+      "source": [
+        "stage_ref = Usd.Stage.Open('sphere_sample.usda')\n",
+        "prim = stage_ref.DefinePrim('/UnTypedPrim')\n",
+        "\n",
+        "if stage_ref.RemovePrim('/UnTypedPrim'):\n",
+        "    print('/UnTypedPrim removed')\n",
+        "\n",
+        "# If you try to access the prim object, it will still reference path but it is\n",
+        "# expired\n",
+        "if (prim.IsValid()):\n",
+        "    print('{} is valid'.format(prim.GetName()))\n",
+        "else:\n",
+        "    print('{} is not valid'.format(prim.GetName()))\n",
+        "  \n",
+        "# The above will print \"Accessed invalid expired prim </UnTypedPrim>\""
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "we85c_IeGppD"
+      },
+      "source": [
+        "## Attributes\n",
+        "Attributes are the workhorse of storing actual data inside a Prim. Attributes are often defined as part of [Schemas](https://graphics.pixar.com/usd/docs/USD-Glossary.html#USDGlossary-Schema) to make it easier to access context-relevant data from within an instance of that Type.\n",
+        "\n",
+        "For example, `Xform` typed Prims have an attribute called `Purpose` which is used to specify the purpose of an imageable prim. It contains one of the following values: `[default, render, proxy, guide]`\n",
+        "\n",
+        "Now, you could get this attribute's value in two ways. One, as a generic `prim_ref.GetAttribute(name)` call, but you would have to know that the exact name of the attribute you want is \"purpose\", and you wouldn't be able to get any code completion in an IDE that way.\n",
+        "\n",
+        "The other way is to use the Xform Schema's exposed function for getting the purpose, which is `xform_ref.GetPurposeAttr()`, which returns the same object, but will be typed in an IDE and does not depend on the underlying string name of the attribute.\n",
+        "\n",
+        "Most often after you get an Attribute object, you will want to get the attribute's actual value or set it. That can be done with *attribute_ref.Get()* to retrieve the value, and `attribute_ref.Set(value)` to set the value.\n",
+        "\n",
+        "Let's see the code for getting an Attribute reference and getting its value:\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Z5qLyZ-NHEtV"
+      },
+      "source": [
+        "stage_ref = Usd.Stage.Open('sphere_sample.usda')\n",
+        "\n",
+        "# Get a reference to the Xform instance as well as a generic Prim instance\n",
+        "xform_ref = UsdGeom.Xform.Define(stage_ref, '/XformPrim')\n",
+        "prim_ref = xform_ref.GetPrim()\n",
+        "\n",
+        "# Get an attribute reference (not its value!)\n",
+        "purpose_from_xform_ref = xform_ref.GetPurposeAttr()\n",
+        "purpose_from_prim_ref = prim_ref.GetAttribute('purpose')\n",
+        "\n",
+        "print(purpose_from_xform_ref == purpose_from_prim_ref) # Prints \"True\"\n",
+        "\n",
+        "# Prints the actual attribute's value, in this case, one of [default, render,\n",
+        "# proxy, guide], since it is the Xform's actual Purpose attribute\n",
+        "print(purpose_from_xform_ref.Get())"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "4QEhnGQXHNFz"
+      },
+      "source": [
+        "To create an attribute that isn't part of a Type's namespace (or it is, but you want to create the attribute \"manually\"), you must pass the attribute name and its type to `prim_ref.CreateAttribute(name, type)`.\n",
+        "\n",
+        "Otherwise, most Types expose a `Set`-style command, for example `xform_ref.SetPurposeAttr(value)`.\n",
+        "\n",
+        "### Working with Attributes\n",
+        "\n",
+        "You can call the `prim_ref.CreateAttribute(name, type)` function to create the attribute, and we can use the information above to select a valid `type`. It returns a reference to the attribute created, which we can set with `attribute_ref.Set(value)`, and again we can construct a valid value by looking up the constructor above."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "gJU_efttH2tU"
+      },
+      "source": [
+        "stage_ref = Usd.Stage.CreateInMemory()\n",
+        "\n",
+        "# Create a Usd.Prim\n",
+        "prim_ref = stage_ref.DefinePrim('/Prim')\n",
+        "\n",
+        "# Create an attribute reference, using an explicit reference to the type\n",
+        "weight_attr = prim_ref.CreateAttribute('weight', Sdf.ValueTypeNames.Float)\n",
+        "\n",
+        "print(weight_attr.Get()) # Prints empty string for default Float values, not 0!\n",
+        "\n",
+        "print(weight_attr.Get() == None) # Prints \"True\"\n",
+        "print(weight_attr.Get() == 0) # Prints \"False\"\n",
+        "\n",
+        "# To set an attribute we use the `attribute_ref.Set(value)` function\n",
+        "weight_attr.Set(42.3)\n",
+        "\n",
+        "print(weight_attr.Get()) # Prints \"42.3\"\n",
+        "\n",
+        "# Also, you can chain calls like so\n",
+        "print(prim_ref.GetPrim().GetAttribute('weight').Get()) # Prints \"42.3\""
+      ],
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Follow along the tutorial using the sample notebook from the GTC session:
 |Notebook|Google Colab link|
 |--------|:----------------:|
 |Introduction to USD|[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NVIDIA-Omniverse/USD-Tutorials-And-Examples/blob/main/ColaboratoryNotebooks/usd_introduction.ipynb)|
+|Opening USD Stages|[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NVIDIA-Omniverse/USD-Tutorials-And-Examples/blob/main/ColaboratoryNotebooks/opening_stages.ipynb)|
+|Prims, Attributes and Metadata|[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NVIDIA-Omniverse/USD-Tutorials-And-Examples/blob/main/ColaboratoryNotebooks/prims_attributes_and_metadata.ipynb)|
+|Hierarchy and Traversal|[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NVIDIA-Omniverse/USD-Tutorials-And-Examples/blob/main/ColaboratoryNotebooks/hierarchy_and_traversal.ipynb)|
 
 ## Additional Resources
  * [Pixar's USD](https://graphics.pixar.com/usd)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For convenience, the Jupyter notebook from the GTC session is available on Googl
 Should you prefer to run the notebook on your local machine instead, simply download and execute it after [installing Jupyter](https://jupyter.org).
 
 ## Sample Notebook
-Follow along the tutorial using the sample notebook from the GTC session:
+Follow along the tutorial using the sample notebook from the GTC session, or get acquainted with USD using other examples:
 
 |Notebook|Google Colab link|
 |--------|:----------------:|


### PR DESCRIPTION
## Goal
Populate the repository with additional USD tutorials and examples, inspired from the [_Working with USD_](https://developer.nvidia.com/usd/tutorials) samples from NVIDIA.

To facilitate the review, these are links to the Jupyter notebooks proposed as part of this Pull Request:

|Notebook|Google Colab link|
|--------|:----------------:|
|Opening USD Stages|[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NVIDIA-Omniverse/USD-Tutorials-And-Examples/blob/add-tutorials-from-nvidia-website/ColaboratoryNotebooks/opening_stages.ipynb)|
|Prims, Attributes and Metadata|[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NVIDIA-Omniverse/USD-Tutorials-And-Examples/blob/add-tutorials-from-nvidia-website/ColaboratoryNotebooks/prims_attributes_and_metadata.ipynb)|
|Hierarchy and Traversal|[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NVIDIA-Omniverse/USD-Tutorials-And-Examples/blob/add-tutorials-from-nvidia-website/ColaboratoryNotebooks/hierarchy_and_traversal.ipynb)|

## Description
This change adds 3 additional tutorials, broken down from the NVIDIA website, in order to allow Users to get introduced to USD libraries and APIs in a Google Colaboratory environment. Reusing some of the existing content available online makes it easy to cross-link between resources, and should make it easier for individuals to follow along.

Note that the notebooks provided as part of this Pull Request also revealed a few typos and broken samples in the _Working with USD_ published online at the time of this writing, which could benefit from being updated.